### PR TITLE
[Add] カートの詳細画面・編集（削除、個数変更、空にする）機能作成

### DIFF
--- a/app/assets/stylesheets/public/items.scss
+++ b/app/assets/stylesheets/public/items.scss
@@ -11,7 +11,6 @@
   display:flex;
   flex-wrap:wrap;
   width: 100%;
-  height: 400px;
 }
 
 .item{

--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -1,13 +1,40 @@
 class Public::CartItemsController < ApplicationController
   def index
-    @cart_items = CartItem.all
+    @my_cart_items = CartItem.where(customer_id: current_customer.id)
+    # @cart_items = CartItem.where(customer_id: params[:id])
   end
 
   def create
-    new_cart_item = CartItem.new(cart_item_params)
-    new_cart_item.customer_id = current_customer.id
-    new_cart_item.item_id = cart_item_params[:item_id]
-    new_cart_item.save
+    # my_cart_itemsの中に、追加しようとしている商品と同じ物は存在しているかでcreateの仕方を変える
+    my_cart_items = CartItem.where(customer_id: current_customer.id)
+    same_cart_item = my_cart_items.find_by( item_id: cart_item_params[:item_id])
+    if same_cart_item.blank?
+      # 同じ商品がなければ、新たに商品を追加
+      new_cart_item = CartItem.new(cart_item_params)
+      new_cart_item.customer_id = current_customer.id
+      new_cart_item.save
+    else
+      # 同じ商品があれば、その商品の個数に数を加算する
+      same_cart_item.update(count: same_cart_item.count + cart_item_params[:count].to_i)
+    end
+    redirect_to public_cart_items_path
+  end
+
+  def destroy
+    cart_item = CartItem.find(params[:id])
+    cart_item.destroy
+    redirect_to public_cart_items_path
+  end
+
+  def destroy_all
+    cart_items = CartItem.where(customer_id: current_customer.id)
+    cart_items.destroy_all
+    redirect_to public_cart_items_path
+  end
+
+  def update
+    cart_item = CartItem.find(params[:id])
+    cart_item.update(count: cart_item_params[:count])
     redirect_to public_cart_items_path
   end
 

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,6 +1,7 @@
 class Public::ItemsController < ApplicationController
   def index
-    @items = Item.all
+    @all_items = Item.all
+    @items = Item.page(params[:page]).per(12).reverse_order
   end
 
   def show

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -2,4 +2,18 @@ class CartItem < ApplicationRecord
 
   belongs_to :customer
   belongs_to :item
+
+  # 小計を求めるメソッド
+  def subtotal_price
+    item.with_tax_price * count
+  end
+
+    # 合計を求めるメソッド
+  def self.calc_total_price(my_cart_items)
+    total_price = 0
+    my_cart_items.each do |cart_item|
+      total_price += cart_item.subtotal_price
+    end
+    total_price
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,6 +6,11 @@ class Item < ApplicationRecord
 
   validates :name, presence: true
   validates :introduction, presence: true
-  validates :image_id, presence: true
+  validates :image, presence: true
   validates :price_without_tax, presence: true
+
+  # 消費税を求めるメソッド
+  def with_tax_price
+      (price_without_tax * 1.1).floor
+  end
 end

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "First" page
-  - available local variables
-    url:           url to the first page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="first">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
-</span>
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,8 +1,3 @@
-<%# Non-link tag that stands for skipped pages...
-  - available local variables
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Last" page
-  - available local variables
-    url:           url to the last page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
-</span>
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Next" page
-  - available local variables
-    url:           url to the next page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
-</span>
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,12 +1,9 @@
-<%# Link showing page number
-  - available local variables
-    page:          a page object for "this" page
-    url:           url to this page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
-</span>
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,25 +1,17 @@
-<%# The container tag
-  - available local variables
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
-    paginator:     the paginator that renders the pagination tags inside
--%>
-<%= paginator.render do -%>
-  <nav class="pagination" role="navigation" aria-label="pager">
-    <%= first_page_tag unless current_page.first? %>
-    <%= prev_page_tag unless current_page.first? %>
-    <% each_page do |page| -%>
-      <% if page.display_tag? -%>
-        <%= page_tag page %>
-      <% elsif !page.was_truncated? -%>
-        <%= gap_tag %>
-      <% end -%>
-    <% end -%>
-    <% unless current_page.out_of_range? %>
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
       <%= next_page_tag unless current_page.last? %>
       <%= last_page_tag unless current_page.last? %>
-    <% end %>
+    </ul>
   </nav>
-<% end -%>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Previous" page
-  - available local variables
-    url:           url to the previous page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
-</span>
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -1,33 +1,87 @@
 <div class = "container">
   <div class = "row">
-    <h3 class = "heading border border-dark bg-light">ショッピングカート</h3>
-  </div>
-  <div class = "mx-auto row">
-    <% if @cart_items.blank? %>
-      <p class = "text-center">カートには何も入っていません</p>
+    <div class = "col-6">
+      <h3 class = "heading border border-dark bg-light d-inline-block">ショッピングカート</h3>
+    </div>
+    <div class = "col-6">
+      <% if @my_cart_items.blank? %>
+        <!--何も表示しない-->
       <% else %>
-        <table class = "table table-bordered">
-          <thead>
-            <tr>
-              <th>商品名</th>
-              <th>単価（税込）</th>
-              <th>数量</th>
-              <th>小計</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            <% @cart_items.each do |cart_item| %>
-              <tr>
-                <td><%=cart_item.item.name %></td>
-                <td><%=cart_item.item.price_without_tax * 1.1 %></td>
-                <td><%=cart_item.count %></td>
-                <td></td>
-                <td></td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-    <% end %>
+        <%= link_to public_destroy_cart_items_path, method: :delete, data: {confirm: "カートを全て空にしますか？"} do %>
+          <button type="button" class="btn btn-danger float-right">カートを空にする</button>
+        <% end %>
+      <% end %>
+    </div>
   </div>
+  <!--カート一覧表-->
+  <% if @my_cart_items.blank? %>
+    <div class = "mx-auto row">
+      <p class = "text-center">カートには何も入っていません</p>
+    </div>
+  <% else %>
+    <div class = "mx-auto row">
+      <table class = "table table-bordered">
+        <thead>
+          <tr class="table-secondary">
+            <th>商品名</th>
+            <th>単価（税込）</th>
+            <th>数量</th>
+            <th>小計</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @my_cart_items.each do |cart_item| %>
+            <tr>
+              <td>
+                <%= attachment_image_tag cart_item.item, :image, :fill, 50, 50, resize:"50×50" %>
+                <%= cart_item.item.name %>
+              </td>
+              <td>
+                <%= "￥#{cart_item.item.with_tax_price.to_s(:delimited)}" %>
+              </td>
+              <td>
+                <%= form_with model: cart_item, url: public_cart_item_path(cart_item) do |f| %>
+                  <%= f.select :count, *[1..9] %>
+                  <%= f.submit '変更', class: "btn btn-success" %>
+                <% end %>
+              </td>
+              <td>
+                <%= "￥#{cart_item.subtotal_price.to_s(:delimited)}" %>
+              </td>
+              <td>
+                <%= link_to public_cart_item_path(cart_item), method: :delete, data: {confirm: "カートから削除しますか？"} do %>
+                  <button type="button" class="btn btn-danger">削除する</button>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    <!--買い物を続けるボタン　と　合計金額-->
+    <div class = "mx-auto row">
+      <div class = "mx-auto col-8">
+        <%= link_to public_items_path do %>
+          <button type="button" class="btn btn-info btn-lg">買い物を続ける</button>
+        <% end %>
+      </div>
+      <div class = "mx-auto col-4">
+        <table class = "table table-bordered">
+          <tr>
+            <th class="table-secondary">合計金額</th>
+            <th><%= "￥#{CartItem.calc_total_price(@my_cart_items).to_s(:delimited)}" %></th>
+          </tr>
+        </table>
+      </div>
+    </div>
+    <!--情報入力画面ボタン-->
+    <div class = "mx-auto row">
+      <div class = "mx-auto col-6 text-center">
+        <%= link_to new_public_order_path do %>
+          <button type="button" class="btn btn-success btn-lg">情報入力画面に進む</button>
+        <% end %>
+      </div>
+    </div>
+<% end %>
 </div>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -4,7 +4,7 @@
     <div class = "col-2">
       <table class = "table table-bordered">
         <thead>
-          <tr>
+          <tr class="table-info">
             <th>ジャンル検索</th>
           </tr>
         </thead>
@@ -22,7 +22,7 @@
     </div>
     <!--商品一覧-->
     <div class = "col-10">
-      <h3 class = "heading">商品一覧<span>（<%= "#{@items.count}件" %>）</span></h3>
+      <h3 class = "heading">商品一覧<span>（<%= "#{@all_items.count}件" %>）</span></h3>
       <div class = "items-list">
         <% if !(@items.blank?) %>
           <% @items.each do |item| %>
@@ -36,6 +36,7 @@
           <% end %>
         <% end %>
       </div>
+      <%= paginate @items %>
     </div>
   </div>
 </div>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -4,7 +4,7 @@
     <div class = "col-2">
       <table class = "table table-bordered">
         <thead>
-          <tr>
+          <tr class="table-info">
             <th>
               ジャンル検索
             </th>
@@ -30,14 +30,23 @@
             <%= attachment_image_tag @item, :image, :fill, 200, 300, resize:"200×300", class:"show-img" %>
           </div>
           <div class = "col-7">
-            <h3><%= @item.name %></h3>
+            <h3>
+              <%= @item.name %>
+              <% if @item.is_sold == true %>
+                <span class = "h6 bg-info text-light px-3 py-1 border border-dark rounded-pill font-weight-bold">販売中</span>
+              <% else %>
+                <span class = "h6 bg-danger text-light px-3 py-1 border border-dark rounded-pill font-weight-bold">売り切れ</span>
+              <% end %>
+            </h3>
             <p class = "mb-5"><%= @item.introduction %></p>
-            <p class = "h4"><%= "￥#{(@item.price_without_tax * @tax_rate).round}（税込）" %> </p>
-            <!--カードに追加フォーム-->
-          　<%= form_with model: @new_cart_item, url:public_cart_items_path do |f| %>
-              <%= f.hidden_field :item_id, value: @item.id %>
-              <%= f.select :count, *[1..9], include_blank: "個数選択" %>
-              <%= f.submit 'カートに入れる', class: "btn btn-success ml-4" %>
+            <p class = "h4"><%= "￥#{@item.with_tax_price.to_s(:delimited)}（税込）" %> </p>
+            <!--カードに追加フォーム（販売中かつログインしなければ表示されない）-->
+            <% if (customer_signed_in?) && (@item.is_sold == true)%>
+            　<%= form_with model: @new_cart_item, url:public_cart_items_path do |f| %>
+                <%= f.hidden_field :item_id, value: @item.id %>
+                <%= f.select :count, *[1..9], include_blank: "個数選択" %>
+                <%= f.submit 'カートに入れる', class: "btn btn-success ml-4" %>
+              <% end %>
             <% end %>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     get "/orders/check", to: "orders#check"
     get "/orders/finish", to: "orders#finish"
     resources :cart_items, only: [:index, :create, :update, :destroy]
-    delete "/cart_items", to: "cart_items#destroy_all"
+    delete "/cart_items", to: "cart_items#destroy_all", as: 'destroy_cart_items'
     resources :delivery_addresses, only: [:index, :edit, :create, :update, :destroy]
   end
 


### PR DESCRIPTION
その他
・同じものをカートに入れた時、個数にそのままプラスされるように
・商品一覧画面のページネーション（１２個以上ならページ切り替え）
・商品詳細画面に販売ステータス（販売中、売り切れ）を表示するように。
・商品詳細画面のカート追加表示をサインインしていないと表示しないように。